### PR TITLE
change : db mount

### DIFF
--- a/Gym_INN_Backend/docker-compose.yml
+++ b/Gym_INN_Backend/docker-compose.yml
@@ -26,7 +26,7 @@ services:
         command:
             mysqld --default-authentication-plugin=mysql_native_password
         volumes:
-            - ./docker/mysql/data:/var/lib/mysql
+            - db-GI:/var/lib/mysql
             - ./docker/mysql/my.cnf:/etc/mysql/conf.d/my.cnf
 
     phpmyadmin:
@@ -41,3 +41,6 @@ services:
             - mysql
         ports:
             - 8080:80
+
+volumes:
+    db-GI:


### PR DESCRIPTION
データベース関連の情報を保存するボリュームのマウント先を変更しました。

ローカルのディレクトリ
↓
Dockerのボリューム

永続化を可能としています。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
	- MySQLサービスのボリューム設定を改善し、データ管理のポータビリティを向上させました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->